### PR TITLE
Only set PG_CONFIG if it is not already set

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,9 @@
 EXTENSION = pgtelemetry
 DATA = extension/*
 
+ifeq ($(PG_CONFIG),)
 PG_CONFIG = pg_config
+endif
 REGRESS = definitions
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)


### PR DESCRIPTION
If we set PG_CONFIG via env we don't want it to be overridden.
This is for example important for Gentoo postgres multislot support.