### PR TITLE
Reflected minimal supported version in the docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,7 @@ In the initial phase, there are several areas of focus for this project:
 
 ## Requirements
 
-Currently this is expected to require PostgreSQL 9.6+. However support for
-PostgreSQL instances before 9.6 is an area of interest and may be added anyway.
+Currently this is expected to require PostgreSQL 10+.
 
 This module also requires that pg_stat_statements is installed.
 


### PR DESCRIPTION
We don't support 9.6 anymore, since https://github.com/adjust/pg-telemetry/commit/fc99c80532dade54f59ff7598263316633b5dd29