### PR TITLE
Fix regression tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -5,6 +5,6 @@ ifeq ($(PG_CONFIG),)
 PG_CONFIG = pg_config
 endif
 REGRESS = definitions
-REGRESS_OPTS = --load-extension=pg_stat_statements
+REGRESS_OPTS = --load-extension=pg_stat_statements --temp-config=extras/regression/postgresql.conf --temp-instance=tmp-regression-test
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)

--- a/Makefile
+++ b/Makefile
@@ -5,5 +5,6 @@ ifeq ($(PG_CONFIG),)
 PG_CONFIG = pg_config
 endif
 REGRESS = definitions
+REGRESS_OPTS = --load-extension=pg_stat_statements
 PGXS := $(shell $(PG_CONFIG) --pgxs)
 include $(PGXS)

--- a/extras/regression/postgresql.conf
+++ b/extras/regression/postgresql.conf
@@ -1,0 +1,1 @@
+shared_preload_libraries = 'pg_stat_statements'


### PR DESCRIPTION
Make regression tests work
Load the missing pg_stat_statements extension before running regression tests

Fix: #19 